### PR TITLE
Set publishWebProjects to false for Publish Internal API build task

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,7 +49,7 @@ steps:
   displayName: 'Publish Internal API'
   inputs:
     command: publish
-    publishWebProjects: true
+    publishWebProjects: false
     projects: 'src\SFA.DAS.RoATPService.Application.Api\SFA.DAS.RoATPService.Application.Api.csproj'
     arguments: '--configuration $(buildConfiguration) --output $(build.artifactstagingdirectory)/publish --no-restore'
 


### PR DESCRIPTION
Set publishWebProjects to false for Publish Internal API build task to resolve build error:

'No web project was found in the repository. Web projects are identified by presence of either a web.config file or wwwroot folder in the directory.'