### PR TITLE
APR-581 revert in process hosting, use Kestrel instead of IIS

### DIFF
--- a/src/SFA.DAS.RoATPService.Application.Api/Program.cs
+++ b/src/SFA.DAS.RoATPService.Application.Api/Program.cs
@@ -31,7 +31,7 @@
             return WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
                 .UseApplicationInsights()
-                .UseIIS()
+                .UseKestrel()
                 .UseNLog();
         }
     }

--- a/src/SFA.DAS.RoATPService.Application.Api/SFA.DAS.RoATPService.Application.Api.csproj
+++ b/src/SFA.DAS.RoATPService.Application.Api/SFA.DAS.RoATPService.Application.Api.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-    <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
This is due to performance overheads introduced by using IIS and the
in process hosting does not fix environment stablility issues