### PR TITLE
FAT2-115 Show active providers only

### DIFF
--- a/src/SFA.DAS.RoATPService.Api.UnitTests/ControllerAuthorizeTests.cs
+++ b/src/SFA.DAS.RoATPService.Api.UnitTests/ControllerAuthorizeTests.cs
@@ -24,7 +24,7 @@ namespace Tests
         {
             var webAssembly = typeof(SearchController).GetTypeInfo().Assembly;
 
-            var controllers = webAssembly.DefinedTypes.Where(c => c.BaseType == typeof(Controller)).ToList();
+            var controllers = webAssembly.DefinedTypes.Where(c => c.BaseType == typeof(Controller) || c.BaseType == typeof(ControllerBase)).ToList();
 
             foreach (var controller in controllers.Where(c => !_controllersThatDoNotRequireAuthorize.Contains(c.Name)))
             {

--- a/src/SFA.DAS.RoATPService.Api.UnitTests/Controllers/FatDataExportControllerTests.cs
+++ b/src/SFA.DAS.RoATPService.Api.UnitTests/Controllers/FatDataExportControllerTests.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Data.SqlTypes;
+using System.Net;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using Castle.Core.Logging;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.RoATPService.Application.Api.Controllers;
+using SFA.DAS.RoATPService.Application.Interfaces;
+
+namespace SFA.DAS.RoATPService.Api.UnitTests.Controllers
+{
+    public class FatDataExportControllerTests
+    {
+        [Test]
+        public async Task When_Calling_GetDataExport_Then_Returns_Data_From_Repository()
+        {
+            var responseFromRepo = new List<object>
+            {
+                new {something = 1, another = 2},
+                new {something = 2, another = 3},
+                new {something = 3, another = 4}
+            };
+            var mockRepository = new Mock<IFatDataExportRepository>();
+            mockRepository
+                .Setup(repository => repository.GetFatDataExport())
+                .ReturnsAsync(responseFromRepo);
+
+            var controller = new FatDataExportController(
+                Mock.Of<ILogger<FatDataExportController>>(), 
+                mockRepository.Object);
+
+            var result = await controller.DataExport() as OkObjectResult;
+
+            result.Value.Should().Be(responseFromRepo);
+        }
+
+        [Test]
+        public async Task When_Calling_GetDataExport_And_SqlException_Then_Returns_NoContent()
+        {
+            var exception = FormatterServices.GetUninitializedObject(typeof(SqlException)) as SqlException; // creating instance of sealed class with private ctor
+
+            var mockRepository = new Mock<IFatDataExportRepository>();
+            mockRepository
+                .Setup(repository => repository.GetFatDataExport())
+                .ThrowsAsync(exception);
+
+            var controller = new FatDataExportController(
+                Mock.Of<ILogger<FatDataExportController>>(), 
+                mockRepository.Object);
+
+            var result = await controller.DataExport() as NoContentResult;
+
+            result.StatusCode.Should().Be((int)HttpStatusCode.NoContent);
+        }
+    }
+}

--- a/src/SFA.DAS.RoATPService.Api.UnitTests/SFA.DAS.RoATPService.Api.UnitTests.csproj
+++ b/src/SFA.DAS.RoATPService.Api.UnitTests/SFA.DAS.RoATPService.Api.UnitTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <ProjectGuid>{08EE85C1-621E-4FE0-AB48-7091C440AAED}</ProjectGuid>
@@ -9,9 +9,11 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.6.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+    <PackageReference Include="Moq" Version="4.12.0" />
     <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SFA.DAS.RoATPService.Application.Api/Controllers/FatDataExportController.cs
+++ b/src/SFA.DAS.RoATPService.Application.Api/Controllers/FatDataExportController.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using SFA.DAS.RoATPService.Application.Api.Middleware;
+using SFA.DAS.RoATPService.Application.Interfaces;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace SFA.DAS.RoATPService.Application.Api.Controllers
+{
+    [ApiController]
+    [Authorize(Roles = "RoATPServiceInternalAPI")]
+    [Route("api/v1/fat-data-export")]
+    public class FatDataExportController : ControllerBase
+    {
+        private readonly ILogger<FatDataExportController> _logger;
+        private readonly IFatDataExportRepository _repository;
+
+        public FatDataExportController(ILogger<FatDataExportController> logger,
+            IFatDataExportRepository repository)
+        {
+            _logger = logger;
+            _repository = repository;
+        }
+
+        [HttpGet("")]
+        [SwaggerResponse((int) HttpStatusCode.OK, Type = typeof(IEnumerable<object>))]
+        [SwaggerResponse((int) HttpStatusCode.BadRequest, typeof(IDictionary<string, string>))]
+        [SwaggerResponse((int) HttpStatusCode.InternalServerError, Type = typeof(ApiResponse))]
+        public async Task<IActionResult> DataExport()
+        {
+            _logger.LogInformation($"Received request for FAT data export");
+
+            try
+            {
+                var result = await _repository.GetFatDataExport();
+                return Ok(result);
+            }
+            catch (SqlException sqlEx)
+            {
+                _logger.LogInformation(
+                    $"Could not generate FAT data export due to : {sqlEx.Message}");
+                return NoContent();
+            }
+        }
+    }
+}

--- a/src/SFA.DAS.RoATPService.Application.Api/StartupConfiguration/Startup.cs
+++ b/src/SFA.DAS.RoATPService.Application.Api/StartupConfiguration/Startup.cs
@@ -139,6 +139,7 @@ namespace SFA.DAS.RoATPService.Application.Api.StartupConfiguration
             services.AddTransient<IHttpContextAccessor, HttpContextAccessor>();
             services.AddTransient(x => Configuration);
             services.AddTransient<IDownloadRegisterRepository, DownloadRegisterRepository>();
+            services.AddTransient<IFatDataExportRepository, FatDataExportRepository>();
             services.AddTransient<ILookupDataRepository, LookupDataRepository>();
             services.AddTransient<IOrganisationRepository, OrganisationRepository>();
             services.AddTransient<IDuplicateCheckRepository, DuplicateCheckRepository>();

--- a/src/SFA.DAS.RoATPService.Application/Interfaces/IFatDataExportRepository.cs
+++ b/src/SFA.DAS.RoATPService.Application/Interfaces/IFatDataExportRepository.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace SFA.DAS.RoATPService.Application.Interfaces
+{
+    public interface IFatDataExportRepository
+    {
+        Task<IEnumerable<object>> GetFatDataExport();
+    }
+}

--- a/src/SFA.DAS.RoATPService.Data.IntegrationTests/Tests/FatDataExportTests.cs
+++ b/src/SFA.DAS.RoATPService.Data.IntegrationTests/Tests/FatDataExportTests.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+using SFA.DAS.RoATPService.Data;
+using SFA.DAS.RoatpService.Data.IntegrationTests.Handlers;
+using SFA.DAS.RoatpService.Data.IntegrationTests.Models;
+using SFA.DAS.RoatpService.Data.IntegrationTests.Services;
+
+namespace SFA.DAS.RoatpService.Data.IntegrationTests.Tests
+{
+    public class FatDataExportTests : TestBase
+    {
+        private FatDataExportRepository _repository;
+
+        [OneTimeSetUp]
+        public void setup()
+        {
+            OrganisationStatusHandler.InsertRecords(
+                new List<OrganisationStatusModel>
+                {
+                    new OrganisationStatusModel { Id = OrganisationStatusHandler.Active, Status = "Active", CreatedAt = DateTime.Now, CreatedBy = "TestSystem" },
+                    new OrganisationStatusModel { Id = OrganisationStatusHandler.Removed, Status = "Removed", CreatedAt = DateTime.Now, CreatedBy = "TestSystem" },
+                    new OrganisationStatusModel { Id = OrganisationStatusHandler.ActiveNotTakingOnApprentices, Status = "Active - but not taking on apprentices", CreatedAt = DateTime.Now, CreatedBy = "TestSystem" },
+                    new OrganisationStatusModel { Id = OrganisationStatusHandler.Onboarding, Status = "On-boarding", CreatedAt = DateTime.Now, CreatedBy = "TestSystem" }
+                });
+            OrganisationTypeHandler.InsertRecords(
+                new List<OrganisationTypeModel>
+                {
+                    new OrganisationTypeModel { Id = 1, Status = "1", Type = "1", CreatedAt = DateTime.Now, CreatedBy = "TestSystem" },
+                    new OrganisationTypeModel { Id = 2, Status = "2", Type = "2", CreatedAt = DateTime.Now, CreatedBy = "TestSystem" },
+                    new OrganisationTypeModel { Id = 3, Status = "3", Type = "3", CreatedAt = DateTime.Now, CreatedBy = "TestSystem" },
+                    new OrganisationTypeModel { Id = 4, Status = "4", Type = "4", CreatedAt = DateTime.Now, CreatedBy = "TestSystem" }
+                });
+            ProviderTypeHandler.InsertRecords(
+                new List<ProviderTypeModel>
+                {
+                    new ProviderTypeModel {Id = 1, Status = "1", ProviderType = "1", CreatedAt = DateTime.Now, CreatedBy = "TestSystem" },
+                    new ProviderTypeModel {Id = 2, Status = "2", ProviderType = "2", CreatedAt = DateTime.Now, CreatedBy = "TestSystem" },
+                    new ProviderTypeModel {Id = 3, Status = "3", ProviderType = "3", CreatedAt = DateTime.Now, CreatedBy = "TestSystem" },
+                    new ProviderTypeModel {Id = 4, Status = "4", ProviderType = "4", CreatedAt = DateTime.Now, CreatedBy = "TestSystem" }
+                });
+
+            _repository = new FatDataExportRepository(new DatabaseService().WebConfiguration);
+        }
+
+        [Test]
+        public void ExpectedLatestDateIsReturnedWithUpdatedTakingPrecedence()
+        {
+            var organisations = new List<OrganisationModel>
+            {
+                new OrganisationModel
+                {
+                    UKPRN = 23423,
+                    ProviderTypeId = 1,
+                    OrganisationTypeId = 1,
+                    StatusId = OrganisationStatusHandler.Removed,
+                    StatusDate = DateTime.Today.AddDays(-10),
+                    LegalName = "Provider 1",
+                    Id = Guid.NewGuid(),
+                    CreatedAt = DateTime.Now,
+                    CreatedBy = "Test"
+                },
+                new OrganisationModel
+                {
+                    UKPRN = 54675,
+                    ProviderTypeId = 2,
+                    OrganisationTypeId = 2,
+                    StatusId = OrganisationStatusHandler.Active,
+                    StatusDate = DateTime.Today.AddDays(-10),
+                    LegalName = "Provider 2",
+                    Id = Guid.NewGuid(),
+                    CreatedAt = DateTime.Now,
+                    CreatedBy = "Test"
+                },
+                new OrganisationModel
+                {
+                    UKPRN = 79878,
+                    ProviderTypeId = 3,
+                    OrganisationTypeId = 3,
+                    StatusId = OrganisationStatusHandler.ActiveNotTakingOnApprentices,
+                    StatusDate = DateTime.Today.AddDays(-10),
+                    LegalName = "Provider 3",
+                    Id = Guid.NewGuid(),
+                    CreatedAt = DateTime.Now,
+                    CreatedBy = "Test"
+                },
+                new OrganisationModel
+                {
+                    UKPRN = 3784,
+                    ProviderTypeId = 4,
+                    OrganisationTypeId = 4,
+                    StatusId = OrganisationStatusHandler.Onboarding,
+                    StatusDate = DateTime.Today.AddDays(-10),
+                    LegalName = "Provider 4",
+                    Id = Guid.NewGuid(),
+                    CreatedAt = DateTime.Now,
+                    CreatedBy = "Test"
+                }
+            };
+            OrganisationHandler.InsertRecords(organisations);
+
+            var dataExportResult = _repository.GetFatDataExport().Result.ToList();
+            dataExportResult.Count.Should().Be(organisations.Count);
+            foreach (var organisation in organisations)
+            {
+                dataExportResult.Should().Contain(obj =>
+                    obj.ToString().Contains(
+                        $"UKPRN = '{organisation.UKPRN}', " +
+                        $"StatusDate = '{organisation.StatusDate}', " +
+                        $"StatusId = '{organisation.StatusId}', " +
+                        $"OrganisationTypeId = '{organisation.OrganisationTypeId}', " +
+                        $"ProviderTypeId = '{organisation.ProviderTypeId}'"));
+            }
+        }
+
+        [OneTimeTearDown]
+        public void tear_down()
+        {
+            OrganisationHandler.DeleteAllRecords();
+            OrganisationStatusHandler.DeleteAllRecords();
+            OrganisationTypeHandler.DeleteAllRecords();
+            ProviderTypeHandler.DeleteAllRecords();
+        }
+    }
+}

--- a/src/SFA.DAS.RoATPService.Data/FatDataExportRepository.cs
+++ b/src/SFA.DAS.RoATPService.Data/FatDataExportRepository.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using System.Data;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Threading.Tasks;
+using Dapper;
+using SFA.DAS.RoATPService.Application.Interfaces;
+using SFA.DAS.RoATPService.Settings;
+
+namespace SFA.DAS.RoATPService.Data
+{
+    public class FatDataExportRepository : IFatDataExportRepository
+    {
+        private readonly IWebConfiguration _configuration;
+        private const string FatDataExportStoredProcedure = "[dbo].[RoATP_FAT_Data_Export]";
+
+        public FatDataExportRepository(IWebConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        public async Task<IEnumerable<object>> GetFatDataExport()
+        {
+            using (var connection = new SqlConnection(_configuration.SqlConnectionString))
+            {
+                if (connection.State != ConnectionState.Open)
+                {
+                    connection.Open();
+                }
+
+                return (await connection.QueryAsync(FatDataExportStoredProcedure, 
+                    commandType: CommandType.StoredProcedure)).OfType<IDictionary<string, object>>().ToList();
+            }
+        }
+    }
+}

--- a/src/SFA.DAS.RoATPService.Database/SFA.DAS.RoATPService.Database.sqlproj
+++ b/src/SFA.DAS.RoATPService.Database/SFA.DAS.RoATPService.Database.sqlproj
@@ -77,6 +77,7 @@
     <Build Include="Tables\OrganisationCategory.sql" />
     <Build Include="Tables\OrganisationCategoryOrgTypeProviderType.sql" />
     <Build Include="Tables\OrganisationStatusEvent.sql" />
+    <Build Include="StoredProcedures\RoATP_FAT_Data_Export.sql" />
   </ItemGroup>
   <ItemGroup>
     <PostDeploy Include="Script.PostDeployment1.sql" />

--- a/src/SFA.DAS.RoATPService.Database/StoredProcedures/RoATP_Complete_Register.sql
+++ b/src/SFA.DAS.RoATPService.Database/StoredProcedures/RoATP_Complete_Register.sql
@@ -23,7 +23,10 @@ SELECT
 	SUBSTRING(JSON_VALUE(OrganisationData, '$.StartDate'), 9, 2) + '/' 
 	+ SUBSTRING(JSON_VALUE(OrganisationData, '$.StartDate'), 6, 2) + '/'
 	+ SUBSTRING(JSON_VALUE(OrganisationData, '$.StartDate'), 0, 5)
-	AS [Date joined]
+	AS [Date joined],
+	o.StatusId,
+	o.OrganisationTypeId,
+	o.ProviderTypeId
 	FROM Organisations o
 	INNER JOIN ProviderTypes pt
 	ON pt.Id = o.ProviderTypeId

--- a/src/SFA.DAS.RoATPService.Database/StoredProcedures/RoATP_Complete_Register.sql
+++ b/src/SFA.DAS.RoATPService.Database/StoredProcedures/RoATP_Complete_Register.sql
@@ -23,10 +23,7 @@ SELECT
 	SUBSTRING(JSON_VALUE(OrganisationData, '$.StartDate'), 9, 2) + '/' 
 	+ SUBSTRING(JSON_VALUE(OrganisationData, '$.StartDate'), 6, 2) + '/'
 	+ SUBSTRING(JSON_VALUE(OrganisationData, '$.StartDate'), 0, 5)
-	AS [Date joined],
-	o.StatusId,
-	o.OrganisationTypeId,
-	o.ProviderTypeId
+	AS [Date joined]
 	FROM Organisations o
 	INNER JOIN ProviderTypes pt
 	ON pt.Id = o.ProviderTypeId

--- a/src/SFA.DAS.RoATPService.Database/StoredProcedures/RoATP_FAT_Data_Export.sql
+++ b/src/SFA.DAS.RoATPService.Database/StoredProcedures/RoATP_FAT_Data_Export.sql
@@ -1,0 +1,13 @@
+﻿CREATE PROCEDURE dbo.RoATP_FAT_Data_Export
+AS
+BEGIN
+SELECT 
+	o.UKPRN,
+	o.StatusDate,
+	o.StatusId,
+	o.OrganisationTypeId,
+	o.ProviderTypeId
+	FROM Organisations o
+	ORDER BY o.LegalName ASC
+END
+GO

--- a/src/SFA.DAS.RoatpService.Data.IntegrationTests/Services/DatabaseService.cs
+++ b/src/SFA.DAS.RoatpService.Data.IntegrationTests/Services/DatabaseService.cs
@@ -11,7 +11,6 @@ namespace SFA.DAS.RoatpService.Data.IntegrationTests.Services
     {
         public DatabaseService()
         {
-
             Configuration = new ConfigurationBuilder()
                 .AddJsonFile("connectionStrings.Local.json")
                 .Build();
@@ -19,10 +18,15 @@ namespace SFA.DAS.RoatpService.Data.IntegrationTests.Services
             {
                 SqlConnectionString = Configuration.GetConnectionString("SqlConnectionStringTest")
             };
+
+            _dbName = Configuration["DatabaseName"];
+            _testDbName = Configuration["TestDatabaseName"];
         }
 
-        public IConfiguration Configuration { get; }
-        public TestWebConfiguration WebConfiguration;
+        private IConfiguration Configuration { get; }
+        private readonly string _dbName;
+        private readonly string _testDbName;
+        public readonly TestWebConfiguration WebConfiguration;
 
         public void SetupDatabase()
         {
@@ -37,7 +41,7 @@ namespace SFA.DAS.RoatpService.Data.IntegrationTests.Services
                 {
                     Connection = connection,
                     CommandText =
-                        $@"DBCC CLONEDATABASE ('SFA.DAS.RoatpService.Database', 'SFA.DAS.RoatpService.Database.Test'); ALTER DATABASE [SFA.DAS.RoatpService.Database.Test] SET READ_WRITE;"
+                        $@"DBCC CLONEDATABASE ('{_dbName}', '{_testDbName}'); ALTER DATABASE [{_testDbName}] SET READ_WRITE;"
                 };
                 var reader = comm.ExecuteReader();
                 reader.Close();
@@ -102,7 +106,7 @@ namespace SFA.DAS.RoatpService.Data.IntegrationTests.Services
                 {
                     Connection = connection,
                     CommandText =
-                        $@"if exists(select * from sys.databases where name = 'SFA.DAS.RoatpService.Database.Test') BEGIN ALTER DATABASE [SFA.DAS.RoatpService.Database.Test] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;  DROP DATABASE [SFA.DAS.RoatpService.Database.Test]; END"
+                        $@"if exists(select * from sys.databases where name = '{_testDbName}') BEGIN ALTER DATABASE [{_testDbName}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;  DROP DATABASE [{_testDbName}]; END"
                 };
                 var reader = comm.ExecuteReader();
                 reader.Close();

--- a/src/SFA.DAS.RoatpService.Data.IntegrationTests/connectionStrings.Template.json
+++ b/src/SFA.DAS.RoatpService.Data.IntegrationTests/connectionStrings.Template.json
@@ -2,7 +2,9 @@
   "ConnectionStrings": {
     "SqlConnectionString": "Data Source={Local db server};Initial Catalog=SFA.DAS.RoatpService.Database;Integrated Security=True;",
     "SqlConnectionStringTest": "Data Source={local db server};Initial Catalog=SFA.DAS.RoatpService.Database.Test;Integrated Security=True;"
-  }
+  },
+  "DatabaseName": "SFA.DAS.RoatpService.Database",
+  "TestDatabaseName": "SFA.DAS.RoatpService.Database.Test"
 }
 // Instructions
 // Make a copy of this, named connectionStrings.Local.json and enter your local datasource in the placeholder


### PR DESCRIPTION
Summary
--
New end point created for usage by FAT v2. 

Notes:
--
I have added the capability to configure the db names for running the integration tests and added the default ones to the connectionStrings template file. Also, there currently no tests covering your `DownloadRegisterRepository.GetCompleteRegister`. The test named as such is testing a different function. I've also added a few minor tweaks to other tests or test projects. The first is to test auth on api controllers (seems you are using mvc controllers), the second is fix assembly errors trying to test the controller (as it makes use of SqlException) - this scenario can now also be tested.